### PR TITLE
🐛 Fix/student authorization : 게시물/댓글 수정, 삭제 작성자도 가능하도록 수정

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/auth/dto/LoginResponse.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/dto/LoginResponse.java
@@ -10,7 +10,7 @@ public class LoginResponse {
     @Schema(description = "사용자 카카오 ID", example = "1")
     private Long id;
 
-    @Schema(description = "사용자 닉네임", example = "YohanKim")
+    @Schema(description = "사용자 닉네임", example = "김요한")
     private String nickname;
 
     @Schema(description = "엑세스 토큰 정보")

--- a/src/main/java/com/ktb10/munggaebe/auth/exception/JwtErrorException.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/exception/JwtErrorException.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class JwtErrorException extends RuntimeException {
 
-    ErrorCode errorCode;
+    private ErrorCode errorCode;
 
     public JwtErrorException(ErrorCode errorCode) {
         super(errorCode.getMessage());

--- a/src/main/java/com/ktb10/munggaebe/auth/exception/JwtErrorException.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/exception/JwtErrorException.java
@@ -1,0 +1,15 @@
+package com.ktb10.munggaebe.auth.exception;
+
+import com.ktb10.munggaebe.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class JwtErrorException extends RuntimeException {
+
+    ErrorCode errorCode;
+
+    public JwtErrorException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/ktb10/munggaebe/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/filter/JwtExceptionFilter.java
@@ -1,0 +1,35 @@
+package com.ktb10.munggaebe.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb10.munggaebe.auth.exception.JwtErrorException;
+import com.ktb10.munggaebe.error.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtErrorException ex) {
+
+            response.setStatus(ex.getErrorCode().getStatus());
+            response.setContentType(APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter()
+                    .write(objectMapper.writeValueAsString(ErrorResponse.from(ex.getErrorCode())));
+        }
+    }
+}

--- a/src/main/java/com/ktb10/munggaebe/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/jwt/JwtTokenProvider.java
@@ -1,9 +1,12 @@
 package com.ktb10.munggaebe.auth.jwt;
 
+import com.ktb10.munggaebe.auth.exception.JwtErrorException;
+import com.ktb10.munggaebe.error.ErrorCode;
 import com.ktb10.munggaebe.member.service.MemberService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -51,16 +54,19 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
+        } catch (SignatureException e) {
+            throw new JwtErrorException(ErrorCode.JWT_INVALID_SIGNATURE);
+        } catch (SecurityException e) {
+            throw new JwtErrorException(ErrorCode.JWT_SECURITY_EXCEPTION);
+        } catch (MalformedJwtException e) {
+            throw new JwtErrorException(ErrorCode.JWT_MALFORMED_TOKEN);
         } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
+            throw new JwtErrorException(ErrorCode.JWT_EXPIRED_TOKEN);
         } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
+            throw new JwtErrorException(ErrorCode.JWT_UNSUPPORTED_TOKEN);
         } catch (IllegalArgumentException e) {
-            log.info("JWT claims string is empty.", e);
+            throw new JwtErrorException(ErrorCode.JWT_ILLEGAL_TOKEN);
         }
-        return false;
     }
 
     public Authentication getAuthentication(String accessToken) {

--- a/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
@@ -143,6 +143,7 @@ public class KakaoService {
             return tokenManager.generateAccessToken(kakaoId, userDetails.getAuthorities());
         }
 
+        log.info("refreshToken inValid = {}", refreshToken);
         throw new RuntimeException("refresh token이 유효하지 않습니다.");
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/config/SecurityConfig.java
+++ b/src/main/java/com/ktb10/munggaebe/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -32,8 +34,6 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/auth/login/oauth2/callback/kakao").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/comments/**", "/api/v1/posts/**").permitAll()
-                                .requestMatchers(HttpMethod.PUT,"/api/v1/comments/**", "/api/v1/posts/**").hasRole("MANAGER")
-                                .requestMatchers(HttpMethod.DELETE,"/api/v1/comments/**", "/api/v1/posts/**").hasRole("MANAGER")
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ktb10/munggaebe/config/SecurityConfig.java
+++ b/src/main/java/com/ktb10/munggaebe/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.ktb10.munggaebe.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ktb10.munggaebe.auth.filter.JwtAuthenticationFilter;
+import com.ktb10.munggaebe.auth.filter.JwtExceptionFilter;
 import com.ktb10.munggaebe.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -36,7 +39,8 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/api/v1/comments/**", "/api/v1/posts/**").permitAll()
                                 .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(objectMapper), JwtAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/com/ktb10/munggaebe/error/ErrorCode.java
+++ b/src/main/java/com/ktb10/munggaebe/error/ErrorCode.java
@@ -17,7 +17,15 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND("POS_002", "해당하는 댓글을 찾을 수 없습니다.", 404),
 
     //OAuth
-    OAUTH_LOGIN_ERROR("OAU_001", "로그인 과정에서 인증 오류가 발생하였습니다.", 500)
+    OAUTH_LOGIN_ERROR("OAU_001", "로그인 과정에서 인증 오류가 발생하였습니다.", 500),
+
+    //JWT
+    JWT_INVALID_SIGNATURE("JWT_001", "유효하지 않은 JWT 서명입니다.", 401),
+    JWT_MALFORMED_TOKEN("JWT_002", "잘못된 형식의 JWT 토큰입니다.", 400),
+    JWT_EXPIRED_TOKEN("JWT_003", "만료된 JWT 토큰입니다.", 401),
+    JWT_UNSUPPORTED_TOKEN("JWT_004", "지원되지 않는 JWT 토큰입니다.", 400),
+    JWT_ILLEGAL_TOKEN("JWT_005", "허용되지 않는 JWT 토큰입니다.", 400),
+    JWT_SECURITY_EXCEPTION("JWT_006", "보안 예외가 발생했습니다.", 403);
     ;
 
     private final String code;

--- a/src/main/java/com/ktb10/munggaebe/error/ErrorExceptionController.java
+++ b/src/main/java/com/ktb10/munggaebe/error/ErrorExceptionController.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.error;
 
+import com.ktb10.munggaebe.auth.exception.JwtErrorException;
 import com.ktb10.munggaebe.auth.exception.OAuthResponseJsonProcessingException;
 import com.ktb10.munggaebe.member.exception.MemberNotFoundException;
 import com.ktb10.munggaebe.member.exception.MemberPermissionDeniedException;
@@ -53,6 +54,15 @@ public class ErrorExceptionController {
     @ExceptionHandler(OAuthResponseJsonProcessingException.class)
     public ResponseEntity<ErrorResponse> handleOAuthResponseJsonProcessingException(OAuthResponseJsonProcessingException e) {
         final ErrorCode errorCode = ErrorCode.OAUTH_LOGIN_ERROR;
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ErrorResponse.from(errorCode));
+    }
+
+    @ExceptionHandler(JwtErrorException.class)
+    public ResponseEntity<ErrorResponse> handleJwtErrorException(JwtErrorException e) {
+        final ErrorCode errorCode = e.getErrorCode();
         log.warn(e.getMessage(), e);
 
         return ResponseEntity.status(errorCode.getStatus())

--- a/src/main/java/com/ktb10/munggaebe/post/controller/CommentController.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/CommentController.java
@@ -77,11 +77,10 @@ public class CommentController {
     @Operation(summary = "댓글 수정", description = "주어진 댓글 ID에 대해 댓글 내용을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
     public ResponseEntity<CommentDto.CommentRes> updateComment(@PathVariable final long commentId,
-                                                               @RequestBody final CommentDto.CommentUpdateReq request,
-                                                               @RequestParam final long memberId) {
+                                                               @RequestBody final CommentDto.CommentUpdateReq request) {
 
         final CommentServiceDto.UpdateReq updateReq = toServiceDto(commentId, request);
-        final Comment comment = commentService.updateComment(updateReq, memberId);
+        final Comment comment = commentService.updateComment(updateReq);
 
         return ResponseEntity.ok(new CommentDto.CommentRes(comment));
     }
@@ -89,10 +88,9 @@ public class CommentController {
     @DeleteMapping("/comments/{commentId}")
     @Operation(summary = "댓글 삭제", description = "주어진 댓글 ID에 대한 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
-    public ResponseEntity<Void> deleteComment(@PathVariable final long commentId,
-                                              @RequestParam final long memberId) {
+    public ResponseEntity<Void> deleteComment(@PathVariable final long commentId) {
 
-        commentService.deleteComment(commentId, memberId);
+        commentService.deleteComment(commentId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/ktb10/munggaebe/post/controller/CommentController.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/CommentController.java
@@ -41,10 +41,9 @@ public class CommentController {
     @Operation(summary = "루트 댓글 생성", description = "새로운 루트 댓글을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "댓글 작성 성공")
     public ResponseEntity<CommentDto.CommentRes> createRootComment(@RequestBody final CommentDto.CommentCreateReq request,
-                                                                   @RequestParam final long postId,
-                                                                   @RequestParam final long memberId) {
+                                                                   @RequestParam final long postId) {
 
-        final Comment comment = commentService.createRootComment(request.toEntity(), postId, memberId);
+        final Comment comment = commentService.createRootComment(request.toEntity(), postId);
 
         return ResponseEntity.created(URI.create("/api/v1/comments/" + comment.getId()))
                 .body(new CommentDto.CommentRes(comment));
@@ -64,10 +63,9 @@ public class CommentController {
     @Operation(summary = "대댓글 생성", description = "주어진 댓글에 대댓글을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "댓글 작성 성공")
     public ResponseEntity<CommentDto.CommentRes> createReplyComment(@PathVariable final long commentId,
-                                                                    @RequestBody final CommentDto.CommentCreateReq request,
-                                                                    @RequestParam final long memberId) {
+                                                                    @RequestBody final CommentDto.CommentCreateReq request) {
 
-        final Comment comment = commentService.createReplyComment(request.toEntity(), commentId, memberId);
+        final Comment comment = commentService.createReplyComment(request.toEntity(), commentId);
 
         return ResponseEntity.created(URI.create("/api/v1/comments/" + comment.getId()))
                 .body(new CommentDto.CommentRes(comment));

--- a/src/main/java/com/ktb10/munggaebe/post/controller/PostController.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/PostController.java
@@ -39,9 +39,9 @@ public class PostController {
     @PostMapping("/posts")
     @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "게시글 작성 성공")
-    public ResponseEntity<PostDto.PostRes> createPost(@RequestBody final PostDto.PostCreateReq request, @RequestParam final long memberId) {
+    public ResponseEntity<PostDto.PostRes> createPost(@RequestBody final PostDto.PostCreateReq request) {
 
-        final Post createdPost = postService.createPost(request.toEntity(), memberId);
+        final Post createdPost = postService.createPost(request.toEntity());
 
         return ResponseEntity.created(URI.create("/api/v1/posts/" + createdPost.getId()))
                 .body(new PostDto.PostRes(createdPost));

--- a/src/main/java/com/ktb10/munggaebe/post/controller/PostController.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/PostController.java
@@ -61,10 +61,9 @@ public class PostController {
     @Operation(summary = "게시글 수정", description = "주어진 ID를 기준으로 게시글을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 수정 성공")
     public ResponseEntity<PostDto.PostRes> updatePost(@PathVariable final long postId,
-                                                      @RequestBody final PostDto.PostUpdateReq request,
-                                                      @RequestParam final long memberId) {
+                                                      @RequestBody final PostDto.PostUpdateReq request) {
         final PostServiceDto.UpdateReq updateReq = toServiceDto(postId, request);
-        final Post updatedPost = postService.updatePost(updateReq, memberId);
+        final Post updatedPost = postService.updatePost(updateReq);
 
         return ResponseEntity.ok(new PostDto.PostRes(updatedPost));
     }
@@ -72,9 +71,9 @@ public class PostController {
     @DeleteMapping("/posts/{postId}")
     @Operation(summary = "게시글 삭제", description = "주어진 ID를 기준으로 게시글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
-    public ResponseEntity<Void> deletePost(@PathVariable final long postId, @RequestParam final long memberId) {
+    public ResponseEntity<Void> deletePost(@PathVariable final long postId) {
 
-        postService.deletePost(postId, memberId);
+        postService.deletePost(postId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/ktb10/munggaebe/post/service/CommentService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/CommentService.java
@@ -46,13 +46,15 @@ public class CommentService {
     }
 
     @Transactional
-    public Comment createRootComment(final Comment entity, final long postId, final long memberId) {
+    public Comment createRootComment(final Comment entity, final long postId) {
+
+        Long currentMemberId = SecurityUtil.getCurrentUserId();
 
         final Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        final Member member = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> new MemberNotFoundException(currentMemberId));
 
         final Comment comment = Comment.builder()
                 .post(post)
@@ -66,7 +68,9 @@ public class CommentService {
     }
 
     @Transactional
-    public Comment createReplyComment(final Comment entity, final long commentId, final long memberId) {
+    public Comment createReplyComment(final Comment entity, final long commentId) {
+
+        Long currentMemberId = SecurityUtil.getCurrentUserId();
 
         final Comment parent = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentNotFoundException(commentId));
@@ -75,8 +79,8 @@ public class CommentService {
         final Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
 
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        final Member member = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> new MemberNotFoundException(currentMemberId));
 
         Comment comment = Comment.builder()
                 .post(post)

--- a/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
@@ -39,10 +39,12 @@ public class PostService {
     }
 
     @Transactional
-    public Post createPost(final Post post, final long memberId) {
+    public Post createPost(final Post post) {
 
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        Long currentMemberId = SecurityUtil.getCurrentUserId();
+
+        final Member member = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> new MemberNotFoundException(currentMemberId));
 
         final Post postWithMember = Post.builder()
                 .member(member)
@@ -79,9 +81,9 @@ public class PostService {
     }
 
     private void validateAuthorization(Post post) {
-        Long currentUserId = SecurityUtil.getCurrentUserId();
-        if (SecurityUtil.hasRole("STUDENT") && !post.getMember().getId().equals(currentUserId)) {
-            throw new MemberPermissionDeniedException(currentUserId, MemberRole.STUDENT);
+        Long currentMemberId = SecurityUtil.getCurrentUserId();
+        if (SecurityUtil.hasRole("STUDENT") && !post.getMember().getId().equals(currentMemberId)) {
+            throw new MemberPermissionDeniedException(currentMemberId, MemberRole.STUDENT);
         }
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/utils/SecurityUtil.java
+++ b/src/main/java/com/ktb10/munggaebe/utils/SecurityUtil.java
@@ -1,0 +1,25 @@
+package com.ktb10.munggaebe.utils;
+
+import com.ktb10.munggaebe.member.domain.Member;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+
+    public static boolean hasRole(String role) {
+        return SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_" + role));
+    }
+
+    public static Member getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Member) {
+            return (Member) authentication.getPrincipal();
+        }
+        throw new RuntimeException("User is not authenticated.");
+    }
+
+    public static Long getCurrentUserId() {
+        return getCurrentUser().getId();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,10 +39,10 @@ springdoc:
 
 kakao:
   key:
-    client-id: 43c3276a70b38834e826316a1e73238f
-#    client-id: 0bd0b44d1c546670862fe8976d4b4905
-  redirect-uri: http://localhost:3000/api/v1/auth/login/oauth2/callback/kakao
-#  redirect-uri: http://localhost:8080/api/v1/auth/login/oauth2/callback/kakao
+#    client-id: 43c3276a70b38834e826316a1e73238f
+    client-id: 0bd0b44d1c546670862fe8976d4b4905
+#  redirect-uri: http://localhost:3000/api/v1/auth/login/oauth2/callback/kakao
+  redirect-uri: http://localhost:8080/api/v1/auth/login/oauth2/callback/kakao
 
 custom:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,10 +39,10 @@ springdoc:
 
 kakao:
   key:
-#    client-id: 43c3276a70b38834e826316a1e73238f
-    client-id: 0bd0b44d1c546670862fe8976d4b4905
-#  redirect-uri: http://localhost:3000/api/v1/auth/login/oauth2/callback/kakao
-  redirect-uri: http://localhost:8080/api/v1/auth/login/oauth2/callback/kakao
+    client-id: 43c3276a70b38834e826316a1e73238f
+#    client-id: 0bd0b44d1c546670862fe8976d4b4905
+  redirect-uri: http://localhost:3000/api/v1/auth/login/oauth2/callback/kakao
+#  redirect-uri: http://localhost:8080/api/v1/auth/login/oauth2/callback/kakao
 
 custom:
   jwt:

--- a/src/test/java/com/ktb10/munggaebe/post/service/CommentServiceTest.java
+++ b/src/test/java/com/ktb10/munggaebe/post/service/CommentServiceTest.java
@@ -97,7 +97,7 @@ class CommentServiceTest {
     void createRootComment_ShouldCreateComment_WhenValidInput() {
         // given
         long postId = 1L;
-        long memberId = 2L;
+        long memberId = 1L;
         Comment entity = Comment.builder().content("New root comment").build();
         Post post = Post.builder().id(postId).build();
         Member member = Member.builder().id(memberId).build();
@@ -107,7 +107,7 @@ class CommentServiceTest {
         given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        Comment result = commentService.createRootComment(entity, postId, memberId);
+        Comment result = commentService.createRootComment(entity, postId);
 
         // then
         assertThat(result).isNotNull();
@@ -119,13 +119,13 @@ class CommentServiceTest {
     void createRootComment_ShouldThrowException_WhenPostNotFound() {
         // given
         long postId = 1L;
-        long memberId = 2L;
+        long memberId = 1L;
         Comment entity = Comment.builder().content("New root comment").build();
 
         given(postRepository.findById(postId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentService.createRootComment(entity, postId, memberId))
+        assertThatThrownBy(() -> commentService.createRootComment(entity, postId))
                 .isInstanceOf(PostNotFoundException.class);
     }
 
@@ -134,13 +134,13 @@ class CommentServiceTest {
     void createRootComment_ShouldThrowException_WhenMemberNotFound() {
         // given
         long postId = 1L;
-        long memberId = 2L;
+        long memberId = 1L;
         Comment entity = Comment.builder().content("New root comment").build();
         given(postRepository.findById(postId)).willReturn(Optional.of(Post.builder().id(postId).build()));
         given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentService.createRootComment(entity, postId, memberId))
+        assertThatThrownBy(() -> commentService.createRootComment(entity, postId))
                 .isInstanceOf(MemberNotFoundException.class);
     }
 
@@ -149,7 +149,7 @@ class CommentServiceTest {
     void createReplyComment_ShouldCreateComment_WhenValidInput() {
         // given
         long commentId = 1L;
-        long memberId = 2L;
+        long memberId = 1L;
 
         Post post = Post.builder().id(1L).build();
         Comment parentComment = Comment.builder().id(commentId).post(post).build();
@@ -162,7 +162,7 @@ class CommentServiceTest {
         given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        Comment result = commentService.createReplyComment(entity, commentId, memberId);
+        Comment result = commentService.createReplyComment(entity, commentId);
 
         // then
         assertThat(result).isNotNull();
@@ -174,13 +174,13 @@ class CommentServiceTest {
     void createReplyComment_ShouldThrowException_WhenParentCommentNotFound() {
         // given
         long commentId = 1L;
-        long memberId = 2L;
+        long memberId = 1L;
         Comment entity = Comment.builder().content("New reply comment").build();
 
         given(commentRepository.findById(commentId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentService.createReplyComment(entity, commentId, memberId))
+        assertThatThrownBy(() -> commentService.createReplyComment(entity, commentId))
                 .isInstanceOf(CommentNotFoundException.class);
     }
 

--- a/src/test/java/com/ktb10/munggaebe/post/service/PostServiceTest.java
+++ b/src/test/java/com/ktb10/munggaebe/post/service/PostServiceTest.java
@@ -9,7 +9,6 @@ import com.ktb10.munggaebe.post.domain.Post;
 import com.ktb10.munggaebe.post.dto.PostServiceDto;
 import com.ktb10.munggaebe.post.exception.PostNotFoundException;
 import com.ktb10.munggaebe.post.repository.PostRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,11 +46,6 @@ class PostServiceTest {
     void setup() {
         Member member = Member.builder().id(1L).role(MemberRole.STUDENT).build();
         setupSecurityContextWithRole(member, "STUDENT");
-    }
-
-    @AfterEach
-    void afterEach() {
-        SecurityContextHolder.clearContext();
     }
 
     private void setupSecurityContextWithRole(Member member, String role) {

--- a/src/test/java/com/ktb10/munggaebe/post/service/PostServiceTest.java
+++ b/src/test/java/com/ktb10/munggaebe/post/service/PostServiceTest.java
@@ -113,7 +113,7 @@ class PostServiceTest {
         given(postRepository.save(any(Post.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        Post result = postService.createPost(post, memberId);
+        Post result = postService.createPost(post);
 
         // then
         assertThat(result).isNotNull();
@@ -127,13 +127,12 @@ class PostServiceTest {
     @DisplayName("게시물을 생성할 때 회원을 찾을 수 없으면 예외를 발생시킨다")
     void createPost_ShouldThrowException_WhenMemberNotFound() {
         // given
-        long memberId = 1L;
         Post post = Post.builder().title("Title").content("Content").build();
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> postService.createPost(post, memberId))
+        assertThatThrownBy(() -> postService.createPost(post))
                 .isInstanceOf(MemberNotFoundException.class);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#7 

## 📝작업 내용

- 버그 수정
  - Before : 매니저만 게시물/댓글 수정, 삭제 접근 가능
  - After : 게시물/댓글 수정, 삭제 작성자도 가능하도록 수정
- 게시물/댓글 요청 형식 변경
  - 모든 요청에서 memberId를 제외
  - 대신, JWT AccessToken 분석해, member 정보 가져옴
- 예외 처리
  - JwtExceptionFilter를 JwtAuthenticationFilter 앞에 추가하여, 인증 과정 예외 처리
  - Refresh Token 검증에 대한 예외 처리
  - ex) Access Token or Refresh Token 만료 시
  - 상태 코드 : 401
<img width="652" alt="image" src="https://github.com/user-attachments/assets/44b1cb99-1a52-431f-9b30-80120a39b120">
