### PR TITLE
🐛 fix: LoginResponse에서 id 대신 memberId, kakaoId 구분해서 반환

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/auth/controller/OAuthController.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/controller/OAuthController.java
@@ -50,7 +50,7 @@ public class OAuthController {
             response.addHeader(SET_COOKIE, cookie.toString());
         }
 
-        return ResponseEntity.ok(new LoginResponse(dto.getId(), dto.getNickname(), dto.getAccessToken()));
+        return ResponseEntity.ok(new LoginResponse(dto.getMemberId(), dto.getKakaoId(), dto.getNickname(), dto.getAccessToken()));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/ktb10/munggaebe/auth/dto/LoginResponse.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/dto/LoginResponse.java
@@ -7,8 +7,11 @@ import lombok.Getter;
 @Schema(description = "로그인 응답")
 public class LoginResponse {
 
-    @Schema(description = "사용자 카카오 ID", example = "1")
-    private Long id;
+    @Schema(description = "사용자 ID", example = "1")
+    private Long memberId;
+
+    @Schema(description = "사용자 카카오 ID", example = "31231231")
+    private Long kakaoId;
 
     @Schema(description = "사용자 닉네임", example = "김요한")
     private String nickname;
@@ -16,8 +19,9 @@ public class LoginResponse {
     @Schema(description = "엑세스 토큰 정보")
     private AccessTokenResponse token;
 
-    public LoginResponse(Long id, String nickname, AccessTokenResponse token) {
-        this.id = id;
+    public LoginResponse(Long memberId, Long kakaoId, String nickname, AccessTokenResponse token) {
+        this.memberId = memberId;
+        this.kakaoId = kakaoId;
         this.nickname = nickname;
         this.token = token;
     }

--- a/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
@@ -120,7 +120,7 @@ public class KakaoService {
         log.info("발급된 AccessToken = {}", accessTokenResponse);
         log.info("발급된 RefreshToken = {}", refreshTokenResponse);
 
-        return new LoginDto(kakaoId, nickName, accessTokenResponse, refreshTokenResponse);
+        return new LoginDto(member.getId(), kakaoId, nickName, accessTokenResponse, refreshTokenResponse);
     }
 
     public AccessTokenResponse regenerateAccessToken(String refreshToken, HttpServletRequest request) {

--- a/src/main/java/com/ktb10/munggaebe/auth/service/dto/LoginDto.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/service/dto/LoginDto.java
@@ -6,13 +6,15 @@ import lombok.Getter;
 
 @Getter
 public class LoginDto {
-    private Long id;
+    private Long memberId;
+    private Long kakaoId;
     private String nickname;
     private AccessTokenResponse accessToken;
     private RefreshTokenResponse refreshToken;
 
-    public LoginDto(Long id, String nickname, AccessTokenResponse accessToken, RefreshTokenResponse refreshToken) {
-        this.id = id;
+    public LoginDto(Long memberId, Long kakaoId, String nickname, AccessTokenResponse accessToken, RefreshTokenResponse refreshToken) {
+        this.memberId = memberId;
+        this.kakaoId = kakaoId;
         this.nickname = nickname;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;


### PR DESCRIPTION
## #️⃣연관된 이슈
#18 
[Slack](https://kakaotech-10.slack.com/archives/C07NNHC0Q69/p1730271694079209)

## 📝작업 내용

LoginResponse에서 id 대신 memberId, kakaoId 구분해서 반환

### 스크린샷
![image](https://github.com/user-attachments/assets/31c12458-d80f-4b2d-820a-cec0a3bb3a73)

