### PR TITLE
🐛 Fix/refresh: 액세스 토큰 재발급 요청 시, JwtAuthenticationFilter에서 막히는 문제 해결

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/filter/JwtAuthenticationFilter.java
@@ -22,6 +22,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("requestURI = {}", request.getRequestURI());
         String token = resolveToken(request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
@@ -30,6 +31,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.equals("/api/v1/auth/refresh");
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
@@ -131,6 +131,8 @@ public class KakaoService {
             throw new RuntimeException("잘못된 access token입니다.");
         }
 
+        log.info("refreshToken = {}", refreshToken);
+        log.info("refreshToken valid 검사");
         if (jwtTokenProvider.validateToken(refreshToken)) {
 
             log.info("validate refreshToken = {}", refreshToken);


### PR DESCRIPTION
## #️⃣연관된 이슈
#20 

## 📝작업 내용

액세스 토큰 재발급 요청 시, JwtAuthenticationFilter에서 막히는 문제 
JwtAuthenticationFilter에서 액세스 토큰 재발급 uri는 제외하는 로직 추가

