### PR TITLE
✨ Feature/member image : 맴버 프로필 이미지 저장 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/image/repository/MemberImageRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/image/repository/MemberImageRepository.java
@@ -1,0 +1,14 @@
+package com.ktb10.munggaebe.image.repository;
+
+import com.ktb10.munggaebe.image.domain.MemberImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberImageRepository extends JpaRepository<MemberImage, Long> {
+
+    @Query("SELECT mi.s3ImagePath FROM MemberImage mi WHERE mi.member.id = :memberId")
+    String findS3ImagePathsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/ktb10/munggaebe/image/service/ImageService.java
+++ b/src/main/java/com/ktb10/munggaebe/image/service/ImageService.java
@@ -1,10 +1,12 @@
 package com.ktb10.munggaebe.image.service;
 
 import com.ktb10.munggaebe.image.domain.ImageType;
+import com.ktb10.munggaebe.image.domain.MemberImage;
 import com.ktb10.munggaebe.image.domain.PostImage;
 import com.ktb10.munggaebe.image.repository.ImageRepository;
 import com.ktb10.munggaebe.image.repository.PostImageRepository;
 import com.ktb10.munggaebe.image.service.dto.UrlDto;
+import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.post.domain.Post;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +67,19 @@ public class ImageService {
         return s3ImagePaths.stream()
                 .map(this::convertS3PathToCloudFront)
                 .toList();
+    }
+
+    public MemberImage saveMemberImage(Member member, UrlDto urls) {
+        log.info("saveMemberImage start : urls = {}", urls);
+
+        MemberImage memberImage = MemberImage.builder()
+                .member(member)
+                .originalName(urls.getFileName())
+                .storedName(getStoredName(urls.getUrl()))
+                .s3ImagePath(urls.getUrl())
+                .build();
+
+        return imageRepository.save(memberImage);
     }
 
     private String convertS3PathToCloudFront(String s3Path) {

--- a/src/main/java/com/ktb10/munggaebe/image/service/ImageService.java
+++ b/src/main/java/com/ktb10/munggaebe/image/service/ImageService.java
@@ -4,6 +4,7 @@ import com.ktb10.munggaebe.image.domain.ImageType;
 import com.ktb10.munggaebe.image.domain.MemberImage;
 import com.ktb10.munggaebe.image.domain.PostImage;
 import com.ktb10.munggaebe.image.repository.ImageRepository;
+import com.ktb10.munggaebe.image.repository.MemberImageRepository;
 import com.ktb10.munggaebe.image.repository.PostImageRepository;
 import com.ktb10.munggaebe.image.service.dto.UrlDto;
 import com.ktb10.munggaebe.member.domain.Member;
@@ -29,6 +30,7 @@ public class ImageService {
 
     private final ImageRepository imageRepository;
     private final PostImageRepository postImageRepository;
+    private final MemberImageRepository memberImageRepository;
     private final S3Service s3Service;
 
     private static final String PREFIX_PATH = "images";
@@ -82,7 +84,20 @@ public class ImageService {
         return imageRepository.save(memberImage);
     }
 
+    public String getMemberImageUrl(long memberId) {
+        log.info("getMemberImageUrl start : memberId = {}", memberId);
+
+        String s3ImagePath = memberImageRepository.findS3ImagePathsByMemberId(memberId);
+        log.info("s3ImagePath = {}", s3ImagePath);
+
+        return convertS3PathToCloudFront(s3ImagePath);
+    }
+
     private String convertS3PathToCloudFront(String s3Path) {
+        if (s3Path == null) {
+            return null;
+        }
+
         String s3PathWithOutParams = s3Path.split("\\?")[0];
         String cloudFrontPath = s3PathWithOutParams.replace(s3Url, cloudfrontUrl);
         log.info("cloudFrontPath = {}", cloudFrontPath);

--- a/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.member.controller;
 
+import com.ktb10.munggaebe.image.service.dto.UrlDto;
 import com.ktb10.munggaebe.member.controller.dto.CourseRes;
 import com.ktb10.munggaebe.member.controller.dto.MemberDto;
 import com.ktb10.munggaebe.member.domain.Member;
@@ -52,6 +53,19 @@ public class MemberController {
         final Member updatedMember = memberService.updateMember(updateReq);
 
         return ResponseEntity.ok(new MemberDto.MemberRes(updatedMember));
+    }
+
+    @PostMapping("/members/{memberId}/images/presigned-url")
+    @Operation(summary = "맴버 이미지 사전 서명 url 생성", description = "S3로부터 사전 서명 url을 생성해 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "맴버 이미지 사전 서명 url 생성 성공")
+    public ResponseEntity<MemberDto.ImagePresignedUrlRes> getPresignedUrl(@PathVariable final long memberId,
+                                                                        @RequestBody final MemberDto.ImagePresignedUrlReq request) {
+        String url = memberService.getPresignedUrl(memberId, request.getFileName());
+
+
+        return ResponseEntity.ok(
+                new MemberDto.ImagePresignedUrlRes(new UrlDto(request.getFileName(), url))
+        );
     }
 
     private static MemberServiceDto.UpdateReq toServiceDto(final long memberId, final MemberDto.MemberUpdateReq request) {

--- a/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
@@ -60,26 +60,26 @@ public class MemberController {
     @PostMapping("/members/{memberId}/images/presigned-url")
     @Operation(summary = "맴버 이미지 사전 서명 url 생성", description = "S3로부터 사전 서명 url을 생성해 반환합니다.")
     @ApiResponse(responseCode = "200", description = "맴버 이미지 사전 서명 url 생성 성공")
-    public ResponseEntity<MemberDto.ImagePresignedUrlRes> getPresignedUrl(@PathVariable final long memberId,
-                                                                        @RequestBody final MemberDto.ImagePresignedUrlReq request) {
+    public ResponseEntity<MemberDto.MemberImagePresignedUrlRes> getPresignedUrl(@PathVariable final long memberId,
+                                                                                @RequestBody final MemberDto.MemberImagePresignedUrlReq request) {
         String url = memberService.getPresignedUrl(memberId, request.getFileName());
 
 
         return ResponseEntity.ok(
-                new MemberDto.ImagePresignedUrlRes(new UrlDto(request.getFileName(), url))
+                new MemberDto.MemberImagePresignedUrlRes(new UrlDto(request.getFileName(), url))
         );
     }
 
     @PostMapping("/members/{memberId}/images")
     @Operation(summary = "맴버 이미지 저장", description = "맴버 이미지 이름과 s3 url을 저장합니다.")
     @ApiResponse(responseCode = "201", description = "맴버 이미지 저장 성공")
-    public ResponseEntity<MemberDto.ImageSaveRes> saveMemberImage(@PathVariable final long memberId,
-                                                               @RequestBody final MemberDto.ImageSaveReq request) {
+    public ResponseEntity<MemberDto.MemberImageSaveRes> saveMemberImage(@PathVariable final long memberId,
+                                                                        @RequestBody final MemberDto.MemberImageSaveReq request) {
 
         MemberImage memberImage = memberService.saveImage(memberId, request.getUrls());
 
         return ResponseEntity.created(URI.create("/api/v1/members/" + memberId))
-                .body(new MemberDto.ImageSaveRes(memberImage));
+                .body(new MemberDto.MemberImageSaveRes(memberImage));
     }
 
     private static MemberServiceDto.UpdateReq toServiceDto(final long memberId, final MemberDto.MemberUpdateReq request) {

--- a/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.member.controller;
 
+import com.ktb10.munggaebe.image.domain.MemberImage;
 import com.ktb10.munggaebe.image.service.dto.UrlDto;
 import com.ktb10.munggaebe.member.controller.dto.CourseRes;
 import com.ktb10.munggaebe.member.controller.dto.MemberDto;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -66,6 +68,18 @@ public class MemberController {
         return ResponseEntity.ok(
                 new MemberDto.ImagePresignedUrlRes(new UrlDto(request.getFileName(), url))
         );
+    }
+
+    @PostMapping("/members/{memberId}/images")
+    @Operation(summary = "맴버 이미지 저장", description = "맴버 이미지 이름과 s3 url을 저장합니다.")
+    @ApiResponse(responseCode = "201", description = "맴버 이미지 저장 성공")
+    public ResponseEntity<MemberDto.ImageSaveRes> saveMemberImage(@PathVariable final long memberId,
+                                                               @RequestBody final MemberDto.ImageSaveReq request) {
+
+        MemberImage memberImage = memberService.saveImage(memberId, request.getUrls());
+
+        return ResponseEntity.created(URI.create("/api/v1/members/" + memberId))
+                .body(new MemberDto.ImageSaveRes(memberImage));
     }
 
     private static MemberServiceDto.UpdateReq toServiceDto(final long memberId, final MemberDto.MemberUpdateReq request) {

--- a/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/MemberController.java
@@ -32,7 +32,7 @@ public class MemberController {
 
         Member member = memberService.findMemberById(memberId);
 
-        return ResponseEntity.ok(new MemberDto.MemberRes(member));
+        return ResponseEntity.ok(new MemberDto.MemberRes(member, memberService.getMemberImageUrl(memberId)));
     }
 
     @GetMapping("/members/course")
@@ -54,7 +54,7 @@ public class MemberController {
         final MemberServiceDto.UpdateReq updateReq = toServiceDto(memberId, request);
         final Member updatedMember = memberService.updateMember(updateReq);
 
-        return ResponseEntity.ok(new MemberDto.MemberRes(updatedMember));
+        return ResponseEntity.ok(new MemberDto.MemberRes(updatedMember, memberService.getMemberImageUrl(memberId)));
     }
 
     @PostMapping("/members/{memberId}/images/presigned-url")

--- a/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.member.controller.dto;
 
+import com.ktb10.munggaebe.image.domain.MemberImage;
 import com.ktb10.munggaebe.image.service.dto.UrlDto;
 import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.member.domain.MemberCourse;
@@ -9,6 +10,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 public class MemberDto {
 
@@ -81,6 +84,40 @@ public class MemberDto {
 
         public ImagePresignedUrlRes(UrlDto urls) {
             this.urls = urls;
+        }
+    }
+
+    @Schema(description = "이미지 저장 요청")
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ImageSaveReq {
+        @Schema(description = "파일 이름, url")
+        private UrlDto urls;
+
+        public ImageSaveReq(UrlDto urls) {
+            this.urls = urls;
+        }
+    }
+
+    @Schema(description = "이미지 저장 응답")
+    @Getter
+    public static class ImageSaveRes {
+        private Long imageId;
+        private Long memberId;
+        private String originalName;
+        private String storedName;
+        private String s3ImagePath;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public ImageSaveRes(MemberImage memberImage) {
+            this.imageId = memberImage.getId();
+            this.memberId = memberImage.getMember().getId();
+            this.originalName = memberImage.getOriginalName();
+            this.storedName = memberImage.getStoredName();
+            this.s3ImagePath = memberImage.getS3ImagePath();
+            this.createdAt = memberImage.getCreatedAt();
+            this.updatedAt = memberImage.getUpdatedAt();
         }
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
@@ -78,23 +78,23 @@ public class MemberDto {
     @Schema(description = "사전 서명 url 요청")
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class ImagePresignedUrlReq {
+    public static class MemberImagePresignedUrlReq {
 
         @Schema(description = "파일 이름 리스트", example = "file1.jpg")
         private String fileName;
 
-        public ImagePresignedUrlReq(String fileName) {
+        public MemberImagePresignedUrlReq(String fileName) {
             this.fileName = fileName;
         }
     }
 
     @Schema(description = "사전 서명 url 응답")
     @Getter
-    public static class ImagePresignedUrlRes {
+    public static class MemberImagePresignedUrlRes {
         @Schema(description = "파일 이름, url")
         private UrlDto urls;
 
-        public ImagePresignedUrlRes(UrlDto urls) {
+        public MemberImagePresignedUrlRes(UrlDto urls) {
             this.urls = urls;
         }
     }
@@ -102,18 +102,18 @@ public class MemberDto {
     @Schema(description = "이미지 저장 요청")
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class ImageSaveReq {
+    public static class MemberImageSaveReq {
         @Schema(description = "파일 이름, url")
         private UrlDto urls;
 
-        public ImageSaveReq(UrlDto urls) {
+        public MemberImageSaveReq(UrlDto urls) {
             this.urls = urls;
         }
     }
 
     @Schema(description = "이미지 저장 응답")
     @Getter
-    public static class ImageSaveRes {
+    public static class MemberImageSaveRes {
         private Long imageId;
         private Long memberId;
         private String originalName;
@@ -122,7 +122,7 @@ public class MemberDto {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
-        public ImageSaveRes(MemberImage memberImage) {
+        public MemberImageSaveRes(MemberImage memberImage) {
             this.imageId = memberImage.getId();
             this.memberId = memberImage.getMember().getId();
             this.originalName = memberImage.getOriginalName();

--- a/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
@@ -54,12 +54,24 @@ public class MemberDto {
         @Schema(description = "회원의 영어 이름", example = "Gildong.Hong")
         private String nameEnglish;
 
+        @Schema(description = "CDN 이미지 url", example = "http://cdn-path/123_file1.jpg")
+        private String imageUrl;
+
         public MemberRes(Member member) {
             this.id = member.getId();
             this.role = member.getRole();
             this.course = member.getCourse();
             this.name = member.getName();
             this.nameEnglish = member.getNameEnglish();
+        }
+
+        public MemberRes(Member member, String imageUrl) {
+            this.id = member.getId();
+            this.role = member.getRole();
+            this.course = member.getCourse();
+            this.name = member.getName();
+            this.nameEnglish = member.getNameEnglish();
+            this.imageUrl = imageUrl;
         }
     }
 

--- a/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.member.controller.dto;
 
+import com.ktb10.munggaebe.image.service.dto.UrlDto;
 import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.member.domain.MemberCourse;
 import com.ktb10.munggaebe.member.domain.MemberRole;
@@ -56,6 +57,30 @@ public class MemberDto {
             this.course = member.getCourse();
             this.name = member.getName();
             this.nameEnglish = member.getNameEnglish();
+        }
+    }
+
+    @Schema(description = "사전 서명 url 요청")
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ImagePresignedUrlReq {
+
+        @Schema(description = "파일 이름 리스트", example = "file1.jpg")
+        private String fileName;
+
+        public ImagePresignedUrlReq(String fileName) {
+            this.fileName = fileName;
+        }
+    }
+
+    @Schema(description = "사전 서명 url 응답")
+    @Getter
+    public static class ImagePresignedUrlRes {
+        @Schema(description = "파일 이름, url")
+        private UrlDto urls;
+
+        public ImagePresignedUrlRes(UrlDto urls) {
+            this.urls = urls;
         }
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
+++ b/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
@@ -124,4 +124,12 @@ public class MemberService implements UserDetailsService {
 
         return imageService.saveMemberImage(member, urls);
     }
+
+    public String getMemberImageUrl(long memberId) {
+
+        if (!memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException(memberId);
+        }
+        return imageService.getMemberImageUrl(memberId);
+    }
 }

--- a/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
+++ b/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.ktb10.munggaebe.member.service;
 
 import com.ktb10.munggaebe.image.domain.ImageType;
+import com.ktb10.munggaebe.image.domain.MemberImage;
 import com.ktb10.munggaebe.image.service.ImageService;
+import com.ktb10.munggaebe.image.service.dto.UrlDto;
 import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.member.domain.MemberCourse;
 import com.ktb10.munggaebe.member.domain.MemberRole;
@@ -73,8 +75,7 @@ public class MemberService implements UserDetailsService {
     public Member updateMember(final MemberServiceDto.UpdateReq updateReq) {
 
         final Long memberId = updateReq.getMemberId();
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        final Member member = findMemberById(memberId);
 
         validateAuthorization(memberId);
 
@@ -112,5 +113,15 @@ public class MemberService implements UserDetailsService {
         validateAuthorization(memberId);
 
         return imageService.getPresignedUrl(fileName, memberId, ImageType.MEMBER);
+    }
+
+    @Transactional
+    public MemberImage saveImage(long memberId, UrlDto urls) {
+
+        Member member = findMemberById(memberId);
+
+        validateAuthorization(memberId);
+
+        return imageService.saveMemberImage(member, urls);
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
+++ b/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.ktb10.munggaebe.member.service;
 
+import com.ktb10.munggaebe.image.domain.ImageType;
+import com.ktb10.munggaebe.image.service.ImageService;
 import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.member.domain.MemberCourse;
 import com.ktb10.munggaebe.member.domain.MemberRole;
@@ -27,6 +29,7 @@ import java.util.Optional;
 public class MemberService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
+    private final ImageService imageService;
 
 
     @Transactional
@@ -81,6 +84,7 @@ public class MemberService implements UserDetailsService {
     }
 
     private void validateAuthorization(final long memberId) {
+        log.info("validateAuthorization memberId");
         final Long currentUserId = SecurityUtil.getCurrentUserId();
         if (currentUserId != memberId) {
             throw new MemberPermissionDeniedException(currentUserId);
@@ -97,5 +101,16 @@ public class MemberService implements UserDetailsService {
     public Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
+    }
+
+    public String getPresignedUrl(final long memberId, final String fileName) {
+
+        if (!memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException(memberId);
+        }
+
+        validateAuthorization(memberId);
+
+        return imageService.getPresignedUrl(fileName, memberId, ImageType.MEMBER);
     }
 }


### PR DESCRIPTION
## 📝작업 내용

-  맴버 프로필 이미지 저장 및 조회 기능 구현
  - 이미지 Presigned url 발급
    - POST /members/{memberId}/images/presigned-url
  - 이미지 fileName, url 저장
    - POST /members/{memberId}/images
  - 맴버 조회, 수정 시 CDN url 같이 반환