### PR TITLE
✨  Feature/save refresh token : 로그아웃 기능 구현

### DIFF
--- a/Dockerfile.spring
+++ b/Dockerfile.spring
@@ -2,6 +2,6 @@ FROM openjdk:21-jdk
 
 WORKDIR /app
 
-COPY build/libs/munggaebe-0.0.2-SNAPSHOT.jar app.jar
+COPY build/libs/munggaebe-0.0.3-SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.ktb10'
-version = '0.0.2-SNAPSHOT'
+version = '0.0.3-SNAPSHOT'
 
 java {
 	toolchain {
@@ -70,6 +70,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	//Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. 문제로 추가
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.94.Final'
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ktb10/munggaebe/auth/controller/OAuthController.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/controller/OAuthController.java
@@ -68,4 +68,27 @@ public class OAuthController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(regeneratedAccessToken);
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃하며, refreshToken을 redis에 저장해 블랙리스트로 관리합니다.")
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    public ResponseEntity<Void> logout(
+            @CookieValue(COOKIE_TOKEN) final String refreshToken,
+            final HttpServletResponse response
+    ) {
+        log.info("logout start");
+
+        kakaoService.logout(refreshToken);
+
+        final ResponseCookie cookie = ResponseCookie.from(COOKIE_TOKEN, "")
+                .maxAge(0)
+//                    .sameSite("None")
+//                    .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.addHeader(SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenHasher.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenHasher.java
@@ -1,0 +1,24 @@
+package com.ktb10.munggaebe.auth.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class TokenHasher {
+    public static String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("토큰 해싱과정에서 문제가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenManager.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenManager.java
@@ -5,12 +5,15 @@ import com.ktb10.munggaebe.auth.service.dto.RefreshTokenResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -18,10 +21,12 @@ import java.util.Date;
 public class TokenManager {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
 
     private static final String BEARER_TYPE = "Bearer";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;	           //1hour
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;    //14days
+    private static final long BLACKLIST_TTL = 1000 * 60 * 60 * 24 * 14;    //14days
 
     public AccessTokenResponse generateAccessToken(String uid, Collection<? extends GrantedAuthority> authorities) {
         log.info("TokenManager.generateAccessToken start");
@@ -48,5 +53,13 @@ public class TokenManager {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    @Transactional
+    public void addBlackList(String refreshToken) {
+        log.info("addBlackList start");
+        String key = "blacklist:refreshToken:" + refreshToken;
+        redisTemplate.opsForValue().set(key, "invalid", BLACKLIST_TTL, TimeUnit.SECONDS);
+        log.info("check save : key = {}, value = {}", key, redisTemplate.opsForValue().get(key));
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenManager.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenManager.java
@@ -58,7 +58,8 @@ public class TokenManager {
     @Transactional
     public void addBlackList(String refreshToken) {
         log.info("addBlackList start");
-        String key = "blacklist:refreshToken:" + refreshToken;
+        String hashedToken = TokenHasher.hashToken(refreshToken);
+        String key = "blacklist:refreshToken:" + hashedToken;
         redisTemplate.opsForValue().set(key, "invalid", BLACKLIST_TTL, TimeUnit.SECONDS);
         log.info("check save : key = {}, value = {}", key, redisTemplate.opsForValue().get(key));
     }

--- a/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenManager.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/jwt/TokenManager.java
@@ -63,4 +63,11 @@ public class TokenManager {
         redisTemplate.opsForValue().set(key, "invalid", BLACKLIST_TTL, TimeUnit.SECONDS);
         log.info("check save : key = {}, value = {}", key, redisTemplate.opsForValue().get(key));
     }
+
+    public boolean isTokenBlacklisted(String refreshToken) {
+        String hashedToken = TokenHasher.hashToken(refreshToken);
+        String key = "blacklist:refreshToken:" + hashedToken;
+        Boolean hasKey = redisTemplate.hasKey(key);
+        return hasKey != null && hasKey;
+    }
 }

--- a/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
@@ -144,28 +144,28 @@ public class KakaoService {
 
         log.info("refreshToken = {}", refreshToken);
         log.info("refreshToken valid 검사");
-        if (jwtTokenProvider.validateToken(refreshToken)) {
+        validateRefreshToken(refreshToken);
 
-            log.info("validate refreshToken = {}", refreshToken);
-            Claims claims = jwtTokenProvider.parseClaims(accessToken);
-            String kakaoId = claims.getSubject();
+        log.info("validate refreshToken = {}", refreshToken);
+        Claims claims = jwtTokenProvider.parseClaims(accessToken);
+        String kakaoId = claims.getSubject();
 
-            UserDetails userDetails = memberService.loadUserByUsername(kakaoId);
-            log.info("userDetails = {}",userDetails);
+        UserDetails userDetails = memberService.loadUserByUsername(kakaoId);
+        log.info("userDetails = {}",userDetails);
 
-            return tokenManager.generateAccessToken(kakaoId, userDetails.getAuthorities());
-        }
-
-        log.info("refreshToken inValid = {}", refreshToken);
-        throw new RuntimeException("refresh token이 유효하지 않습니다.");
+        return tokenManager.generateAccessToken(kakaoId, userDetails.getAuthorities());
     }
 
     public void logout(String refreshToken) {
-
-//        if (!jwtTokenProvider.validateToken(refreshToken)) {
-//            throw new RuntimeException("refresh token이 유효하지 않습니다.");
-//        }
-
+        validateRefreshToken(refreshToken);
         tokenManager.addBlackList(refreshToken);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (tokenManager.isTokenBlacklisted(refreshToken)) {
+            throw new IllegalArgumentException("이미 무효화된 토큰입니다.");
+        }
+
+        jwtTokenProvider.validateToken(refreshToken);
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
+++ b/src/main/java/com/ktb10/munggaebe/auth/service/KakaoService.java
@@ -3,14 +3,14 @@ package com.ktb10.munggaebe.auth.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ktb10.munggaebe.auth.service.dto.AccessTokenResponse;
-import com.ktb10.munggaebe.auth.service.dto.RefreshTokenResponse;
-import com.ktb10.munggaebe.auth.exception.OAuthResponseJsonProcessingException;
 import com.ktb10.munggaebe.auth.client.KakaoAuthClient;
 import com.ktb10.munggaebe.auth.client.KakaoMemberApiClient;
+import com.ktb10.munggaebe.auth.exception.OAuthResponseJsonProcessingException;
 import com.ktb10.munggaebe.auth.jwt.JwtTokenProvider;
 import com.ktb10.munggaebe.auth.jwt.TokenManager;
+import com.ktb10.munggaebe.auth.service.dto.AccessTokenResponse;
 import com.ktb10.munggaebe.auth.service.dto.LoginDto;
+import com.ktb10.munggaebe.auth.service.dto.RefreshTokenResponse;
 import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.member.service.MemberService;
 import com.ktb10.munggaebe.member.service.dto.MemberServiceDto;
@@ -158,5 +158,14 @@ public class KakaoService {
 
         log.info("refreshToken inValid = {}", refreshToken);
         throw new RuntimeException("refresh token이 유효하지 않습니다.");
+    }
+
+    public void logout(String refreshToken) {
+
+//        if (!jwtTokenProvider.validateToken(refreshToken)) {
+//            throw new RuntimeException("refresh token이 유효하지 않습니다.");
+//        }
+
+        tokenManager.addBlackList(refreshToken);
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/config/RedisConfig.java
+++ b/src/main/java/com/ktb10/munggaebe/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.ktb10.munggaebe.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private String port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(port));
+        redisStandaloneConfiguration.setPassword(password);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

- 로그아웃 기능 구현
  - POST `/api/v1/auth/logout`
- 로그아웃 시, Redis에 해당 refreshToken를 BlackList에 추가
  - 추가할 때, SHA-256 해싱해서 저장
- refreshToken 사용 시(액세스 토큰 재발급, 로그아웃), 해당 refreshToken이 BlackList에 포함되는지 검증 추가
