### PR TITLE
✨ Feature/notification additional : 알림 기능 추가

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/config/SecurityConfig.java
+++ b/src/main/java/com/ktb10/munggaebe/config/SecurityConfig.java
@@ -46,8 +46,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeRequests(auth -> auth
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()  // POST /api/v1/auth/**만 허용
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/comments/**", "/api/v1/posts/**", "/api/v1/members/**").permitAll()
+                        .requestMatchers("/api/v1/notifications/subscribe").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/ktb10/munggaebe/notification/controller/NotificationController.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/controller/NotificationController.java
@@ -56,7 +56,7 @@ public class NotificationController {
     @GetMapping("/me")
     @Operation(summary = "내 알림 조회", description = "나의 알림들을 조회해서 반환합니다.")
     @ApiResponse(responseCode = "200", description = "내 알림 조회 성공")
-    public ResponseEntity<?> myNotifications(@RequestParam(required = false, defaultValue = DEFAULT_NOTIFICATION_PAGE_NO) final int pageNo,
+    public ResponseEntity<Page<NotificationDto.NotificationRes>> myNotifications(@RequestParam(required = false, defaultValue = DEFAULT_NOTIFICATION_PAGE_NO) final int pageNo,
                                              @RequestParam(required = false, defaultValue = DEFAULT_NOTIFICATION_PAGE_SIZE) final int pageSize) {
 
         final Page<Notification> notifications = notificationPersistenceService.findAllMyNotifications(pageNo, pageSize);

--- a/src/main/java/com/ktb10/munggaebe/notification/controller/NotificationController.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/controller/NotificationController.java
@@ -63,4 +63,13 @@ public class NotificationController {
 
         return ResponseEntity.ok(notifications.map(NotificationDto.NotificationRes::new));
     }
+
+    @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "알림 읽음 처리", description = "알림 읽음 처리합니다.")
+    @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공")
+    public ResponseEntity<NotificationDto.NotificationRes> readNotification(@PathVariable final Long notificationId) {
+        final Notification notification = notificationPersistenceService.markNotificationAsRead(notificationId);
+
+        return ResponseEntity.ok(new NotificationDto.NotificationRes(notification));
+    }
 }

--- a/src/main/java/com/ktb10/munggaebe/notification/controller/NotificationController.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/controller/NotificationController.java
@@ -1,19 +1,20 @@
 package com.ktb10.munggaebe.notification.controller;
 
+import com.ktb10.munggaebe.notification.controller.dto.NotificationDto;
+import com.ktb10.munggaebe.notification.domain.Notification;
 import com.ktb10.munggaebe.notification.domain.NotificationType;
 import com.ktb10.munggaebe.notification.service.NotificationEventPublisher;
+import com.ktb10.munggaebe.notification.service.NotificationPersistenceService;
 import com.ktb10.munggaebe.notification.service.NotificationService;
 import com.ktb10.munggaebe.notification.service.dto.NotificationEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
@@ -23,7 +24,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final NotificationPersistenceService notificationPersistenceService;
     private final NotificationEventPublisher publisher;
+
+    private static final String DEFAULT_NOTIFICATION_PAGE_NO = "0";
+    private static final String DEFAULT_NOTIFICATION_PAGE_SIZE = "10";
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "알림 SSE 연결", description = "알림 SSE 연결 시도합니다.")
@@ -46,5 +51,16 @@ public class NotificationController {
                 .build());
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 알림 조회", description = "나의 알림들을 조회해서 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "내 알림 조회 성공")
+    public ResponseEntity<?> myNotifications(@RequestParam(required = false, defaultValue = DEFAULT_NOTIFICATION_PAGE_NO) final int pageNo,
+                                             @RequestParam(required = false, defaultValue = DEFAULT_NOTIFICATION_PAGE_SIZE) final int pageSize) {
+
+        final Page<Notification> notifications = notificationPersistenceService.findAllMyNotifications(pageNo, pageSize);
+
+        return ResponseEntity.ok(notifications.map(NotificationDto.NotificationRes::new));
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/notification/controller/dto/NotificationDto.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/controller/dto/NotificationDto.java
@@ -2,19 +2,32 @@ package com.ktb10.munggaebe.notification.controller.dto;
 
 import com.ktb10.munggaebe.notification.domain.Notification;
 import com.ktb10.munggaebe.notification.domain.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 public class NotificationDto {
 
+    @Schema(description = "알림 응답")
     @Getter
     public static class NotificationRes {
+        @Schema(description = "알림 ID", example = "1")
         private Long id;
+
+        @Schema(description = "알림 종류", example = "ANNOUNCEMENT")
         private NotificationType type;
+
+        @Schema(description = "알림 메세지", example = "이런저런 공지사항입니다.")
         private String message;
+
+        @Schema(description = "알림 읽음 여부", example = "false")
         private boolean isRead;
+
+        @Schema(description = "알림 생성 시간", example = "2024-10-15T10:15:30")
         private LocalDateTime createdAt;
+
+        @Schema(description = "알림 수정 시간", example = "2024-10-15T10:15:30")
         private LocalDateTime updatedAt;
 
         public NotificationRes(Notification notification) {

--- a/src/main/java/com/ktb10/munggaebe/notification/controller/dto/NotificationDto.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/controller/dto/NotificationDto.java
@@ -1,0 +1,29 @@
+package com.ktb10.munggaebe.notification.controller.dto;
+
+import com.ktb10.munggaebe.notification.domain.Notification;
+import com.ktb10.munggaebe.notification.domain.NotificationType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class NotificationDto {
+
+    @Getter
+    public static class NotificationRes {
+        private Long id;
+        private NotificationType type;
+        private String message;
+        private boolean isRead;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public NotificationRes(Notification notification) {
+            this.id = notification.getId();
+            this.type = notification.getType();
+            this.message = notification.getMessage();
+            this.isRead = notification.isRead();
+            this.createdAt = notification.getCreatedAt();
+            this.updatedAt = notification.getUpdatedAt();
+        }
+    }
+}

--- a/src/main/java/com/ktb10/munggaebe/notification/domain/Notification.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/domain/Notification.java
@@ -51,4 +51,8 @@ public class Notification {
         this.message = message;
         this.isRead = isRead;
     }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/ktb10/munggaebe/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/repository/NotificationRepository.java
@@ -1,9 +1,12 @@
 package com.ktb10.munggaebe.notification.repository;
 
 import com.ktb10.munggaebe.notification.domain.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    Page<Notification> findAllByMemberId(Pageable pageable, Long memberId);
 }

--- a/src/main/java/com/ktb10/munggaebe/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/repository/NotificationRepository.java
@@ -3,10 +3,15 @@ package com.ktb10.munggaebe.notification.repository;
 import com.ktb10.munggaebe.notification.domain.Notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Page<Notification> findAllByMemberId(Pageable pageable, Long memberId);
+
+    List<Notification> findByMemberIdAndIdGreaterThan(Long userId, Long lastEventId, Sort sort);
 }

--- a/src/main/java/com/ktb10/munggaebe/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/repository/SseEmitterRepository.java
@@ -15,7 +15,13 @@ public class SseEmitterRepository {
     private final ConcurrentHashMap<Long, SseEmitter> userEmitters = new ConcurrentHashMap<>();
 
     public SseEmitter save(Long userId, SseEmitter sseEmitter) {
-        userEmitters.putIfAbsent(userId, sseEmitter);
+        SseEmitter removedEmitter = userEmitters.remove(userId);
+        if (removedEmitter != null) {
+            removedEmitter.complete();
+        }
+
+        userEmitters.put(userId, sseEmitter);
+
         return findById(userId).orElseThrow(() -> new IllegalStateException("저장 실패"));
     }
 

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
@@ -74,7 +74,7 @@ public class NotificationPersistenceService {
     }
 
     private void validateAuthorization(Notification notification) {
-        log.info("validateAuthorization Post's memberId");
+        log.info("validateAuthorization Notification's memberId");
         Long currentMemberId = SecurityUtil.getCurrentUserId();
         if (SecurityUtil.hasRole("STUDENT") && !notification.getMember().getId().equals(currentMemberId)) {
             throw new MemberPermissionDeniedException(currentMemberId, MemberRole.STUDENT);

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -42,6 +43,17 @@ public class NotificationPersistenceService {
         log.info("saveUnicasting start: receiverId = {}", event.getReceiverId());
         Member member = findMemberByReceiverId(event.getReceiverId());
         notificationRepository.save(event.toEntity(member));
+    }
+
+    @Transactional
+    public Notification markNotificationAsRead(long notificationId) {
+        log.info("markNotificationAsRead start: notificationId = {}", notificationId);
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 알림입니다. notificationId = " + notificationId));
+
+        notification.markAsRead();
+
+        return notification;
     }
 
     public Page<Notification> findAllMyNotifications(int pageNo, int pageSize) {

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
@@ -80,4 +80,17 @@ public class NotificationPersistenceService {
             throw new MemberPermissionDeniedException(currentMemberId, MemberRole.STUDENT);
         }
     }
+
+    public List<Notification> getMissingNotifications(Long userId, String lastEventId) {
+        long lastEventIdAsLong;
+        try {
+            lastEventIdAsLong = Long.parseLong(lastEventId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("잘못된 형식의 lastEventId입니다. lastEventId = " + lastEventId);
+        }
+
+        Sort sort = Sort.by(Sort.Direction.ASC, "createdAt");
+
+        return notificationRepository.findByMemberIdAndIdGreaterThan(userId, lastEventIdAsLong, sort);
+    }
 }

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
@@ -1,6 +1,7 @@
 package com.ktb10.munggaebe.notification.service;
 
 import com.ktb10.munggaebe.member.domain.Member;
+import com.ktb10.munggaebe.member.domain.MemberRole;
 import com.ktb10.munggaebe.member.exception.MemberNotFoundException;
 import com.ktb10.munggaebe.member.repository.MemberRepository;
 import com.ktb10.munggaebe.notification.repository.NotificationRepository;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -22,7 +25,10 @@ public class NotificationPersistenceService {
     @Transactional
     public void saveBroadCasting(NotificationEvent event) {
         log.info("saveBroadCasting start");
-        notificationRepository.save(event.toEntity());
+        List<Member> members = memberRepository.findAll();
+        members.stream()
+                .filter(m -> m.getRole().equals(MemberRole.STUDENT))
+                .forEach(member -> notificationRepository.save(event.toEntity(member)));
     }
 
     @Transactional

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationPersistenceService.java
@@ -4,10 +4,16 @@ import com.ktb10.munggaebe.member.domain.Member;
 import com.ktb10.munggaebe.member.domain.MemberRole;
 import com.ktb10.munggaebe.member.exception.MemberNotFoundException;
 import com.ktb10.munggaebe.member.repository.MemberRepository;
+import com.ktb10.munggaebe.notification.domain.Notification;
 import com.ktb10.munggaebe.notification.repository.NotificationRepository;
 import com.ktb10.munggaebe.notification.service.dto.NotificationEvent;
+import com.ktb10.munggaebe.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +44,16 @@ public class NotificationPersistenceService {
         notificationRepository.save(event.toEntity(member));
     }
 
-    public Member findMemberByReceiverId(long receiverId) {
+    public Page<Notification> findAllMyNotifications(int pageNo, int pageSize) {
+        log.info("findAllMyNotifications start");
+
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
+        Long memberId = SecurityUtil.getCurrentUserId();
+
+        return notificationRepository.findAllByMemberId(pageable, memberId);
+    }
+
+    private Member findMemberByReceiverId(long receiverId) {
         return memberRepository.findById(receiverId)
                 .orElseThrow(() -> new MemberNotFoundException(receiverId));
     }

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationService.java
@@ -36,14 +36,16 @@ public class NotificationService {
         emitter.onTimeout(() -> emitterRepository.deleteById(userId));
         emitter.onError((e) -> emitterRepository.deleteById(userId));
 
-        sendToEmitter(userId, emitter, "SSE 연결 성공 : userId = " + userId, "connect_success");
+        SseEmitter savedEmitter = emitterRepository.save(userId, emitter);
+
+        sendToEmitter(userId, savedEmitter, "SSE 연결 성공 : userId = " + userId, "connect_success");
 
         if (!lastEventId.isBlank()) {
             List<Notification> missingNotifications = notificationPersistenceService.getMissingNotifications(userId, lastEventId);
-            missingNotifications.forEach(notify -> sendToEmitter(userId, emitter, notify.getMessage(), "notification"));
+            missingNotifications.forEach(notify -> sendToEmitter(userId, savedEmitter, notify.getMessage(), "notification"));
         }
 
-        return emitterRepository.save(userId, emitter);
+        return savedEmitter;
     }
 
     public void handleNotificationEvent(NotificationEvent event) {

--- a/src/main/java/com/ktb10/munggaebe/notification/service/NotificationService.java
+++ b/src/main/java/com/ktb10/munggaebe/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.notification.service;
 
+import com.ktb10.munggaebe.notification.domain.Notification;
 import com.ktb10.munggaebe.notification.repository.SseEmitterRepository;
 import com.ktb10.munggaebe.notification.service.dto.NotificationEvent;
 import com.ktb10.munggaebe.utils.SecurityUtil;
@@ -37,7 +38,10 @@ public class NotificationService {
 
         sendToEmitter(userId, emitter, "SSE 연결 성공 : userId = " + userId, "connect_success");
 
-        //NotificationRepository에서 lastEventId 이후의 notifications를 해당 유저에게 다시 전송
+        if (!lastEventId.isBlank()) {
+            List<Notification> missingNotifications = notificationPersistenceService.getMissingNotifications(userId, lastEventId);
+            missingNotifications.forEach(notify -> sendToEmitter(userId, emitter, notify.getMessage(), "notification"));
+        }
 
         return emitterRepository.save(userId, emitter);
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -64,6 +64,17 @@ CREATE TABLE IF NOT EXISTS member_image (
     FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS notification (
+    notification_id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id BIGINT,
+    type VARCHAR(50) NOT NULL,
+    message VARCHAR(255) NOT NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (notification_id),
+    FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE SET NULL
+);
 
 -- Member 데이터 삽입
 INSERT IGNORE INTO member (member_id, role, course, member_name, member_name_english, kakao_id, created_at, updated_at) VALUES
@@ -149,3 +160,16 @@ INSERT IGNORE INTO post_image (image_id, post_id) VALUES
 INSERT IGNORE INTO member_image (image_id, member_id) VALUES
 (4, 1),
 (5, 2);
+
+INSERT IGNORE INTO notification (notification_id, member_id, type, message, is_read, created_at, updated_at) VALUES
+(1, 1, 'MENTION', 'You have a new comment on your post.', false, NOW(), NOW()),
+(2, 2, 'MENTION', 'Your post has been liked by Kim Cheol-su.', false, DATE_ADD(NOW(), INTERVAL -1 DAY), DATE_ADD(NOW(), INTERVAL -1 DAY)),
+(3, 6, 'MENTION', 'Your post has been liked by Yoo Jae-suk.', false, DATE_ADD(NOW(), INTERVAL -4 DAY), DATE_ADD(NOW(), INTERVAL -4 DAY)),
+(4, 1, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(5, 2, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(6, 3, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(7, 4, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(8, 5, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(9, 6, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(10, 7, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
+(11, 8, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY));


### PR DESCRIPTION
## 📝작업 내용

- lastEventId 활용하게 구현
  - GET /notifications/subscribe 에서 request header로 Last-Event-ID 넣어주면 됨.
  - 해당 유저에게 lastEventId 이후의 알림들을 보내주게됨
  - SSE 연결이 끊겼다가 재연결되는 경우 사용해야하고, 새로고침 등 DB 조회하게 될 때는 사용하면 안됨.
  - 클라이언트에서 새로고침 등 DB 조회하게 될 때, lastEventId를 최신화 할 것.
- 특정 userId로 notification 조회 api
  - GET /notifications/me
- 읽었을 때 is_read 수정 api
  - PATCH /notifications/{notificationId}/read