### PR TITLE
✨ feat: 회원가입 후 맴버 정보 업데이트 시, ElasticSearch에 맴버 저장

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/member/service/ElasticsearchMemberService.java
+++ b/src/main/java/com/ktb10/munggaebe/member/service/ElasticsearchMemberService.java
@@ -1,0 +1,37 @@
+package com.ktb10.munggaebe.member.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ElasticsearchMemberService {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    private static final String INDEX_NAME = "members";
+
+    public void addMember(String name, String nameEnglish) {
+        try {
+            IndexResponse response = elasticsearchClient.index(i -> i
+                    .index(INDEX_NAME)
+                    .document(Map.of(
+                            "name", name,
+                            "alias", nameEnglish
+                    ))
+            );
+
+            log.info("Document added to index '{}': ID = {}, Result = {}", INDEX_NAME, response.id(), response.result());
+        } catch (IOException e) {
+            log.error("Failed to add document to index '{}': {}", INDEX_NAME, e.getMessage(), e);
+            throw new RuntimeException("Failed to add document to Elasticsearch", e);
+        }
+    }
+}

--- a/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
+++ b/src/main/java/com/ktb10/munggaebe/member/service/MemberService.java
@@ -36,6 +36,7 @@ public class MemberService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
     private final ImageService imageService;
+    private final ElasticsearchMemberService elasticsearchMemberService;
     private final ObjectMapper objectMapper;
 
 
@@ -85,6 +86,7 @@ public class MemberService implements UserDetailsService {
         validateAuthorization(memberId);
 
         member.updateMember(updateReq.getName(), updateReq.getNameEnglish(), updateReq.getCourse());
+        elasticsearchMemberService.addMember(updateReq.getName(), updateReq.getNameEnglish());
 
         return member;
     }


### PR DESCRIPTION
## 📝작업 내용

- 회원가입 후 맴버 정보 업데이트 시, ElasticSearch에 맴버 저장
  - `PATCH /members/{memberId}`api 호출 시, 동작함.
