### PR TITLE
✨ Feature/reservation deadline : 게시물 예약 시간, 마감 시간 등록

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/post/controller/PostController.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/PostController.java
@@ -131,8 +131,12 @@ public class PostController {
     @GetMapping("/posts/announcements/near-deadline")
     @Operation(summary = "마감되지 않은 공지사항 조회", description = "마감되지 않은 공지사항 게시물을 마감임박순으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "마감되지 않은 공지사항 조회 성공")
-    public ResponseEntity<Page<PostDto.PostRes>> getAnnouncementsPostsNearDeadline() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Page<PostDto.PostRes>> getAnnouncementsPostsNearDeadline(@RequestParam(required = false, defaultValue = DEFAULT_POST_PAGE_NO) final int pageNo,
+                                                                                   @RequestParam(required = false, defaultValue = DEFAULT_POST_PAGE_SIZE) final int pageSize) {
+
+        Page<Post> posts = postService.getAnnouncementsPostsNearDeadline(pageNo, pageSize);
+
+        return ResponseEntity.ok(posts.map(this::appendCdnPaths));
     }
 
     private static PostServiceDto.UpdateReq toServiceDto(final long postId, final PostDto.PostUpdateReq request) {

--- a/src/main/java/com/ktb10/munggaebe/post/controller/dto/PostDto.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/dto/PostDto.java
@@ -96,6 +96,12 @@ public class PostDto {
         @Schema(description = "게시글 수정 시간", example = "2024-10-15T11:15:30")
         private LocalDateTime updatedAt;
 
+        @Schema(description = "게시글 예약 시간", example = "2024-12-12T10:00:00")
+        private LocalDateTime reservationTime;
+
+        @Schema(description = "게시글 마감 시간", example = "2024-12-19T23:59:59")
+        private LocalDateTime deadLine;
+
         @Schema(description = "게시물 작성자 정보", implementation = MemberDto.MemberRes.class)
         private MemberDto.MemberRes member;
 
@@ -112,6 +118,8 @@ public class PostDto {
             this.content = post.getContent();
             this.createdAt = post.getCreatedAt();
             this.updatedAt = post.getUpdatedAt();
+            this.reservationTime = post.getReservationTime();
+            this.deadLine = post.getDeadLine();
             this.member = new MemberDto.MemberRes(post.getMember());
             this.isClean = post.isClean();
         }
@@ -122,6 +130,8 @@ public class PostDto {
             this.content = post.getContent();
             this.createdAt = post.getCreatedAt();
             this.updatedAt = post.getUpdatedAt();
+            this.reservationTime = post.getReservationTime();
+            this.deadLine = post.getDeadLine();
             this.member = new MemberDto.MemberRes(post.getMember());
             this.isClean = post.isClean();
             this.imageUrls = imageUrls;

--- a/src/main/java/com/ktb10/munggaebe/post/controller/dto/PostDto.java
+++ b/src/main/java/com/ktb10/munggaebe/post/controller/dto/PostDto.java
@@ -42,6 +42,8 @@ public class PostDto {
             return Post.builder()
                     .title(this.title)
                     .content(this.content)
+                    .reservationTime(this.reservationTime)
+                    .deadLine(this.deadLine)
                     .build();
         }
     }

--- a/src/main/java/com/ktb10/munggaebe/post/domain/Post.java
+++ b/src/main/java/com/ktb10/munggaebe/post/domain/Post.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
@@ -46,7 +45,6 @@ public class Post {
     @Column(name = "is_clean", nullable = false)
     private boolean isClean;
 
-    @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
@@ -54,13 +52,23 @@ public class Post {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "reservation_time")
+    private LocalDateTime reservationTime;
+
+    @Column(name = "dead_line")
+    private LocalDateTime deadLine;
+
     @Builder
-    public Post(Long id, Member member, String title, String content, boolean isClean) {
+    public Post(Long id, Member member, Channel channel, String title, String content, boolean isClean, LocalDateTime createdAt, LocalDateTime reservationTime, LocalDateTime deadLine) {
         this.id = id;
         this.member = member;
+        this.channel = channel;
         this.title = title;
         this.content = content;
         this.isClean = isClean;
+        this.createdAt = createdAt;
+        this.reservationTime = reservationTime;
+        this.deadLine = deadLine;
     }
 
     public void updatePost(String title, String content, boolean isClean) {

--- a/src/main/java/com/ktb10/munggaebe/post/repository/PostRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/post/repository/PostRepository.java
@@ -1,9 +1,15 @@
 package com.ktb10.munggaebe.post.repository;
 
 import com.ktb10.munggaebe.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByCreatedAtBefore(LocalDateTime time, Pageable pageable);
 }

--- a/src/main/java/com/ktb10/munggaebe/post/repository/PostRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/post/repository/PostRepository.java
@@ -12,4 +12,6 @@ import java.time.LocalDateTime;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByCreatedAtBefore(LocalDateTime time, Pageable pageable);
+
+    Page<Post> findByChannelIdAndDeadLineIsNotNull(Long channelId, Pageable pageable);
 }

--- a/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
 
     public Page<Post> getPosts(final int pageNo, final int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
-        return postRepository.findAll(pageable);
+        return postRepository.findByCreatedAtBefore(LocalDateTime.now(), pageable);
     }
 
     public Post getPost(final long postId) {

--- a/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
@@ -44,6 +44,8 @@ public class PostService {
     private final ObjectMapper objectMapper;
     private final ChannelRepository channelRepository;
 
+    private static final Long ANNOUNCEMENT_CHANNEL_ID = 1L;
+
     public Page<Post> getPosts(final int pageNo, final int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
         return postRepository.findByCreatedAtBefore(LocalDateTime.now(), pageable);
@@ -163,6 +165,11 @@ public class PostService {
             return postImage;
         }
         throw new IllegalStateException("해당 이미지가 PostImage 타입이 아닙니다.");
+    }
+
+    public Page<Post> getAnnouncementsPostsNearDeadline(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("deadLine"));
+        return postRepository.findByChannelIdAndDeadLineIsNotNull(ANNOUNCEMENT_CHANNEL_ID, pageable);
     }
 
     private void validateAuthorization(Post post) {

--- a/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
@@ -1,6 +1,8 @@
 package com.ktb10.munggaebe.post.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb10.munggaebe.channel.domain.Channel;
+import com.ktb10.munggaebe.channel.repository.ChannelRepository;
 import com.ktb10.munggaebe.image.domain.Image;
 import com.ktb10.munggaebe.image.domain.ImageType;
 import com.ktb10.munggaebe.image.domain.PostImage;
@@ -26,6 +28,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -39,6 +42,7 @@ public class PostService {
     private final ImageService imageService;
     private final FilteringService filteringService;
     private final ObjectMapper objectMapper;
+    private final ChannelRepository channelRepository;
 
     public Page<Post> getPosts(final int pageNo, final int pageSize) {
         Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by("createdAt").descending());
@@ -61,10 +65,17 @@ public class PostService {
         boolean isPostClean = isPostClean(post.getTitle(), post.getContent());
         log.info("createPost isPostClean = {}", isPostClean);
 
+        //임시 채널
+        Channel channel = channelRepository.findById(1L).orElse(null);
+
         final Post postWithMember = Post.builder()
                 .member(member)
+                .channel(channel)
                 .title(post.getTitle())
                 .content(post.getContent())
+                .createdAt(post.getReservationTime() == null ? LocalDateTime.now() : post.getReservationTime())
+                .reservationTime(post.getReservationTime())
+                .deadLine(post.getDeadLine())
                 .isClean(isPostClean)
                 .build();
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -128,7 +128,8 @@ INSERT INTO channel (channel_name) VALUES
 ('공지'),
 ('풀스택'),
 ('클라우드'),
-('인공지능');
+('인공지능'),
+('학습게시판');
 
 -- 채널 데이터 삽입
 INSERT INTO member_channel (channel_id, member_id) VALUES

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -27,6 +27,8 @@ CREATE TABLE IF NOT EXISTS post (
     is_clean BOOLEAN NOT NULL DEFAULT TRUE,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    reservation_time DATETIME,
+    dead_line DATETIME,
     PRIMARY KEY (post_id),
     FOREIGN KEY (member_id) REFERENCES member(member_id) ON DELETE CASCADE,
     FOREIGN KEY (channel_id) REFERENCES channel(channel_id) ON DELETE CASCADE
@@ -120,6 +122,21 @@ INSERT IGNORE INTO member (member_id, role, course, member_name, member_name_eng
 (19, 'STUDENT', 'FULLSTACK', '차은우', 'Cha Eun-woo', 1234567909, NOW(), NOW()),
 (20, 'STUDENT', 'AI', '송혜교', 'Song Hye-kyo', 1234567910, NOW(), NOW());
 
+
+       -- 채널 데이터 삽입
+INSERT INTO channel (channel_name) VALUES
+('공지'),
+('풀스택'),
+('클라우드'),
+('인공지능');
+
+-- 채널 데이터 삽입
+INSERT INTO member_channel (channel_id, member_id) VALUES
+(1, 1),
+(1, 3),
+(2, 5),
+(3, 6);
+
 -- Post 데이터 삽입
 --INSERT IGNORE INTO post (post_id, member_id, post_title, post_content, created_at, updated_at, is_clean) VALUES
 --(1, 1, 'First Post', 'This is the content of the first post', NOW(), NOW(), true),
@@ -144,27 +161,27 @@ INSERT IGNORE INTO member (member_id, role, course, member_name, member_name_eng
 --(20, 20, 'Twentieth Post', 'This is the content of the twentieth post', DATE_ADD(NOW(), INTERVAL 5 HOUR), DATE_ADD(NOW(), INTERVAL 5 HOUR), true);
 
 -- Post 데이터 삽입 (channel_id 추가)
-INSERT IGNORE INTO post (post_id, member_id, channel_id, post_title, post_content, created_at, updated_at, is_clean) VALUES
-(1, 1, 1, 'First Post', 'This is the content of the first post', NOW(), NOW(), true),
-(2, 2, 1, 'Second Post', 'This is the content of the second post', NOW(), NOW(), true),
-(3, 3, 2, 'Third Post', 'This is the content of the third post', NOW(), NOW(), true),
-(4, 4, 2, 'Fourth Post', 'This is the content of the fourth post', NOW(), NOW(), true),
-(5, 5, 3, 'Fifth Post', 'This is the content of the fifth post', NOW(), NOW(), true),
-(6, 6, 3, 'Sixth Post', 'This is the content of the sixth post', NOW(), NOW(), true),
-(7, 7, 4, 'Seventh Post', 'This is the content of the seventh post', NOW(), NOW(), true),
-(8, 8, 4, 'Eighth Post', 'This is the content of the eighth post', NOW(), NOW(), true),
-(9, 9, 4, 'Ninth Post', 'This is the content of the ninth post', NOW(), NOW(), true),
-(10, 10, 4, 'Tenth Post', 'This is the content of the tenth post', NOW(), NOW(), true),
-(11, 11, 4, 'Eleventh Post', 'This is the content of the eleventh post', DATE_ADD(NOW(), INTERVAL 1 HOUR), DATE_ADD(NOW(), INTERVAL 1 HOUR), true),
-(12, 12, 4, 'Twelfth Post', 'This is the content of the twelfth post', DATE_ADD(NOW(), INTERVAL 1 HOUR), DATE_ADD(NOW(), INTERVAL 1 HOUR), true),
-(13, 13, 4, 'Thirteenth Post', 'This is the content of the thirteenth post', DATE_ADD(NOW(), INTERVAL 1 HOUR), DATE_ADD(NOW(), INTERVAL 2 HOUR), true),
-(14, 14, 4, 'Fourteenth Post', 'This is the content of the fourteenth post', DATE_ADD(NOW(), INTERVAL 1 HOUR), DATE_ADD(NOW(), INTERVAL 2 HOUR), true),
-(15, 15, 4, 'Fifteenth Post', 'This is the content of the fifteenth post', DATE_ADD(NOW(), INTERVAL 1 HOUR), DATE_ADD(NOW(), INTERVAL 2 HOUR), true),
-(16, 16, 4, 'Sixteenth Post', 'This is the content of the sixteenth post', DATE_ADD(NOW(), INTERVAL 2 HOUR), DATE_ADD(NOW(), INTERVAL 2 HOUR), true),
-(17, 17, 4, 'Seventeenth Post', 'This is the content of the seventeenth post', DATE_ADD(NOW(), INTERVAL 2 HOUR), DATE_ADD(NOW(), INTERVAL 2 HOUR), true),
-(18, 18, 4, '개자식아', 'This is the content of the eighteenth post', DATE_ADD(NOW(), INTERVAL 3 HOUR), DATE_ADD(NOW(), INTERVAL 3 HOUR), false),
-(19, 19, 4, 'Nineteenth Post', '개자식아', DATE_ADD(NOW(), INTERVAL 4 HOUR), DATE_ADD(NOW(), INTERVAL 4 HOUR), false),
-(20, 20, 4, 'Twentieth Post', 'This is the content of the twentieth post', DATE_ADD(NOW(), INTERVAL 5 HOUR), DATE_ADD(NOW(), INTERVAL 5 HOUR), true);
+INSERT IGNORE INTO post (post_id, member_id, channel_id, post_title, post_content, created_at, updated_at, reservation_time, dead_line, is_clean) VALUES
+(1, 1, 1, 'First Post', 'This is the content of the first post', DATE_ADD(NOW(), INTERVAL -4 DAY), DATE_ADD(NOW(), INTERVAL -4 DAY), null, DATE_ADD(NOW(), INTERVAL 6 DAY), true),
+(2, 2, 1, 'Second Post', 'This is the content of the second post', DATE_ADD(NOW(), INTERVAL -4 DAY), DATE_ADD(NOW(), INTERVAL -4 DAY), null, DATE_ADD(NOW(), INTERVAL 5 DAY), true),
+(3, 3, 1, 'Third Post', 'This is the content of the third post', DATE_ADD(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 1 DAY), DATE_ADD(NOW(), INTERVAL 4 DAY), true),
+(4, 4, 1, 'Fourth Post', 'This is the content of the fourth post', DATE_ADD(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 2 DAY), DATE_ADD(NOW(), INTERVAL 3 DAY), true),
+(5, 5, 2, 'Fifth Post', 'This is the content of the fifth post', NOW(), NOW(), null, null, true),
+(6, 6, 2, 'Sixth Post', 'This is the content of the sixth post', NOW(), NOW(), null, null, true),
+(7, 7, 2, 'Seventh Post', 'This is the content of the seventh post', NOW(), NOW(), null, null, true),
+(8, 8, 2, 'Eighth Post', 'This is the content of the eighth post', NOW(), NOW(), null, null, true),
+(9, 9, 2, 'Ninth Post', 'This is the content of the ninth post', NOW(), NOW(), null, null, true),
+(10, 10, 3, 'Tenth Post', 'This is the content of the tenth post', NOW(), NOW(), null, null, true),
+(11, 11, 3, 'Eleventh Post', 'This is the content of the eleventh post', NOW(), NOW(), null, null, true),
+(12, 12, 3, 'Twelfth Post', 'This is the content of the twelfth post', NOW(), NOW(), null, null, true),
+(13, 13, 3, 'Thirteenth Post', 'This is the content of the thirteenth post', NOW(), NOW(), null, null, true),
+(14, 14, 3, 'Fourteenth Post', 'This is the content of the fourteenth post', NOW(), NOW(), null, null, true),
+(15, 15, 3, 'Fifteenth Post', 'This is the content of the fifteenth post', NOW(), NOW(), null, null, true),
+(16, 16, 4, 'Sixteenth Post', 'This is the content of the sixteenth post', NOW(), NOW(), null, null, true),
+(17, 17, 4, 'Seventeenth Post', 'This is the content of the seventeenth post', NOW(), NOW(), null, null, true),
+(18, 18, 4, '개자식아', 'This is the content of the eighteenth post', NOW(), NOW(), null, null, false),
+(19, 19, 4, 'Nineteenth Post', '개자식아', NOW(), NOW(), null, null, false),
+(20, 20, 4, 'Twentieth Post', 'This is the content of the twentieth post', NOW(), NOW(), null, null, true);
 
 -- Comment 데이터 삽입
 INSERT IGNORE INTO comment (comment_id, post_id, member_id, parent_comment_id, comment_content, depth, created_at, updated_at, is_clean) VALUES
@@ -218,16 +235,4 @@ INSERT IGNORE INTO notification (notification_id, member_id, type, message, is_r
 (10, 7, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY)),
 (11, 8, 'ANNOUNCEMENT', 'ANNOUNCEMENT1', false, DATE_ADD(NOW(), INTERVAL -2 DAY), DATE_ADD(NOW(), INTERVAL -2 DAY));
 
--- 채널 데이터 삽입
-INSERT INTO channel (channel_name) VALUES
-('공지'),
-('풀스택'),
-('클라우드'),
-('인공지능');
 
--- 채널 데이터 삽입
-INSERT INTO member_channel (channel_id, member_id) VALUES
-(1, 1),
-(1, 3),
-(2, 5),
-(3, 6);


### PR DESCRIPTION
## 📝작업 내용

- 게시물 생성 시, 예약 시간, 마감 시간 받도록 구현
- 게시물 목록 조회 시, 현재시간 이전의 createdAt을 가진 게시물 조회하도록 수정
- 공지사항 마감임박 순 조회
  - `GET /api/v1/posts/announcements/near-deadline`
  - 마감시간 없으면 조회 안함