### PR TITLE
🚑 채널 기능 api 및 로직 수정

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/channel/controller/ChannelController.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/controller/ChannelController.java
@@ -38,12 +38,12 @@ public class ChannelController {
     }
 
     @PostMapping("/channels/{channelId}/members")
-    @Operation(summary = "채널에 멤버 추가", description = "특정 채널에 멤버를 추가합니다.")
+    @Operation(summary = "채널에 멤버 추가", description = "매니저가 특정 채널에 멤버를 추가합니다.")
     @ApiResponse(responseCode = "202", description = "채널에 멤버 추가 성공")
     public ResponseEntity<MemberDto.ChannelMemberResponse> addMembersToChannel(
             @PathVariable Long channelId,
             @RequestBody MemberDto.MemberAddReq memberAddReq) {
-        MemberDto.ChannelMemberResponse response = channelService.addMembers(channelId, memberAddReq.getMemberIds());
+        MemberDto.ChannelMemberResponse response = channelService.addMembers(channelId, memberAddReq);
         return ResponseEntity.accepted().body(response);
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/channel/dto/ChannelRequest.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/dto/ChannelRequest.java
@@ -14,7 +14,4 @@ import lombok.Setter;
 public class ChannelRequest {
     @Schema(description = "채널 이름", example = "스터디 그룹 A")
     private String name;
-
-    @Schema(description = "게시글 작성 권한", example = "true")
-    private Boolean canPost;
 }

--- a/src/main/java/com/ktb10/munggaebe/channel/dto/ChannelResponse.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/dto/ChannelResponse.java
@@ -17,7 +17,4 @@ public class ChannelResponse {
 
     @Schema(description = "채널 이름", example = "스터디 그룹 A")
     private String name;
-
-    @Schema(description = "해당 채널에 게시물 업로드 가능 여부", example = "true")
-    private Boolean canPost;
 }

--- a/src/main/java/com/ktb10/munggaebe/channel/service/ChannelService.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/service/ChannelService.java
@@ -8,6 +8,7 @@ import com.ktb10.munggaebe.member.controller.dto.MemberDto;
 import com.ktb10.munggaebe.channel.repository.ChannelRepository;
 import com.ktb10.munggaebe.channel.domain.Channel;
 import com.ktb10.munggaebe.member.domain.Member;
+import com.ktb10.munggaebe.member.domain.MemberRole;
 import com.ktb10.munggaebe.member.repository.MemberRepository;
 import com.ktb10.munggaebe.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,7 @@ public class ChannelService {
         Long currentMemberId = SecurityUtil.getCurrentUserId();
 
         //매니저 권한인 경우 모든 채널 조회
-        if (SecurityUtil.hasRole("MANAGER")) {
+        if (SecurityUtil.hasRole(MemberRole.MANAGER.name())) {
             List<Channel> allChannels = channelRepository.findAll();
             return allChannels.stream()
                     .map(channel -> new ChannelResponse(
@@ -60,7 +61,7 @@ public class ChannelService {
 
     @Transactional
     public ChannelResponse createChannel(ChannelRequest channelRequest) {
-        if (!SecurityUtil.hasRole("MANAGER")) {
+        if (!SecurityUtil.hasRole(MemberRole.MANAGER.name())) {
             throw new RuntimeException("Only managers can create channels.");
         }
 
@@ -77,7 +78,7 @@ public class ChannelService {
 
     @Transactional
     public MemberDto.ChannelMemberResponse addMembers(Long channelId, MemberDto.MemberAddReq memberAddReq) {
-        if (!SecurityUtil.hasRole("MANAGER")) {
+        if (!SecurityUtil.hasRole(MemberRole.MANAGER.name())) {
             throw new RuntimeException("Only managers can add members to a channel.");
         }
 

--- a/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
+++ b/src/main/java/com/ktb10/munggaebe/member/controller/dto/MemberDto.java
@@ -177,6 +177,9 @@ public class MemberDto {
     @Getter
     @NoArgsConstructor
     public static class MemberAddReq {
+        @Schema(description = "게시글 작성 권한", example = "true")
+        private Boolean canPost;
+
         @Schema(description = "추가할 멤버 ID 리스트", example = "[1, 2, 3]")
         private List<Long> memberIds;
 
@@ -188,6 +191,9 @@ public class MemberDto {
     @Getter
     @AllArgsConstructor
     public static class ChannelMemberResponse {
+        @Schema(description = "게시글 작성 권한", example = "true")
+        private Boolean canPost;
+
         @Schema(description = "채널 ID", example = "1")
         private Long channelId;
 

--- a/src/main/java/com/ktb10/munggaebe/member/repository/MemberRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/member/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.ktb10.munggaebe.member.repository;
 
 import com.ktb10.munggaebe.member.domain.Member;
+import com.ktb10.munggaebe.member.domain.MemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByKakaoId(Long kakaoId);
 
     Optional<Member> findByNameEnglish(String nameEnglish);
+
+    List<Member> findAllByRole(MemberRole role); // 매니저 조회 메서드
 }


### PR DESCRIPTION
## 📝작업 내용
- 채널 기능 로직에서 기존에 채널을 생성할때 학생의 게시글 작성 여부를 받았는데, 이를 멤버 추가시 받도록 변경했습니다.
- 채널 생성과 채널에 멤버를 추가하는 기능은 매니저만 할 수 있도록 수정했습니다.
- 채널 생성 시, 모든 매니저를 해당 채널에 추가하도록 수정했습니다.

[Channel api 변경사항]
- `GET /channels` 채널 목록 조회: Responses에 canPost 삭제
- `POST /channels` 채널 생성: Responses, Request body에 canPost 삭제
- `POST /channels/{channelId}/members` 채널에 멤버 추가: Responses, Request body에 canPost 추가
    ```
    {
      "canPost": true,
      "memberIds": [1, 2, 3]
    }
    ```



