### PR TITLE
🚑  멤버 게시글 작성 권한 확인 후 게시글을 작성하도록 수정

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/channel/repository/MemberChannelRepository.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/repository/MemberChannelRepository.java
@@ -3,7 +3,9 @@ package com.ktb10.munggaebe.channel.repository;
 import com.ktb10.munggaebe.channel.domain.Channel;
 import com.ktb10.munggaebe.channel.domain.MemberChannel;
 import com.ktb10.munggaebe.member.domain.Member;
+import feign.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -12,4 +14,7 @@ public interface MemberChannelRepository extends JpaRepository<MemberChannel, Lo
     boolean existsByChannelAndMember(Channel channel, Member member);
 
     List<MemberChannel> findByChannelId(long channelId);
+
+    @Query("SELECT mc.canPost FROM MemberChannel mc WHERE mc.channel.id = :channelId AND mc.member.id = :memberId")
+    Boolean findCanPostByChannelIdAndMemberId(@Param("channelId") Long channelId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/ktb10/munggaebe/post/exception/PermissionException.java
+++ b/src/main/java/com/ktb10/munggaebe/post/exception/PermissionException.java
@@ -1,0 +1,9 @@
+package com.ktb10.munggaebe.post.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PermissionException extends RuntimeException {
+
+    public PermissionException() { super("게시글을 작성할 수 있는 권한이 없습니다."); }
+}

--- a/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ktb10.munggaebe.aicomment.service.AiCommentService;
 import com.ktb10.munggaebe.channel.domain.Channel;
 import com.ktb10.munggaebe.channel.repository.ChannelRepository;
+import com.ktb10.munggaebe.channel.repository.MemberChannelRepository;
 import com.ktb10.munggaebe.image.domain.Image;
 import com.ktb10.munggaebe.image.domain.ImageType;
 import com.ktb10.munggaebe.image.domain.PostImage;
@@ -46,6 +47,7 @@ public class PostService {
     private final ObjectMapper objectMapper;
     private final ChannelRepository channelRepository;
     private final AiCommentService aiCommentService;
+    private final MemberChannelRepository memberChannelRepository;
 
     private static final Long ANNOUNCEMENT_CHANNEL_ID = 1L;
     private static final String EDUCATION_CHANNEL_NAME = "학습게시판";
@@ -86,6 +88,12 @@ public class PostService {
 
         Channel channel = channelRepository.findById(channelId)
                 .orElseThrow(() -> new IllegalArgumentException("Channel not found with id: " + channelId));
+
+        //멤버 canPost 권한 확인
+        Boolean canPost = memberChannelRepository.findCanPostByChannelIdAndMemberId(channelId, currentMemberId);
+        if (canPost == null || !canPost) {
+            throw new RuntimeException("You do not have permission to create a post in this channel.");
+        }
 
         final Member member = memberRepository.findById(currentMemberId)
                 .orElseThrow(() -> new MemberNotFoundException(currentMemberId));

--- a/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
+++ b/src/main/java/com/ktb10/munggaebe/post/service/PostService.java
@@ -17,6 +17,7 @@ import com.ktb10.munggaebe.member.exception.MemberNotFoundException;
 import com.ktb10.munggaebe.member.exception.MemberPermissionDeniedException;
 import com.ktb10.munggaebe.member.repository.MemberRepository;
 import com.ktb10.munggaebe.post.domain.Post;
+import com.ktb10.munggaebe.post.exception.PermissionException;
 import com.ktb10.munggaebe.post.exception.PostNotFoundException;
 import com.ktb10.munggaebe.post.repository.PostRepository;
 import com.ktb10.munggaebe.post.service.dto.PostServiceDto;
@@ -92,7 +93,7 @@ public class PostService {
         //멤버 canPost 권한 확인
         Boolean canPost = memberChannelRepository.findCanPostByChannelIdAndMemberId(channelId, currentMemberId);
         if (canPost == null || !canPost) {
-            throw new RuntimeException("You do not have permission to create a post in this channel.");
+            throw new PermissionException();
         }
 
         final Member member = memberRepository.findById(currentMemberId)


### PR DESCRIPTION
## 📝작업 내용
특정 채널에서 게시글 작성 시, MemberChannel에서 해당 채널 ID에 있는 맴버 ID를 확인해여 canPost가 true일 경우에만 게시글을 작성할 수 있도록 수정했습니다.


