### PR TITLE
✨ 특정 채널 상세 조회 기능 및 api 구현

### DIFF
--- a/src/main/java/com/ktb10/munggaebe/channel/controller/ChannelController.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/controller/ChannelController.java
@@ -1,5 +1,6 @@
 package com.ktb10.munggaebe.channel.controller;
 
+import com.ktb10.munggaebe.channel.domain.Channel;
 import com.ktb10.munggaebe.channel.dto.ChannelRequest;
 import com.ktb10.munggaebe.channel.dto.ChannelResponse;
 import com.ktb10.munggaebe.channel.service.ChannelService;
@@ -45,5 +46,14 @@ public class ChannelController {
             @RequestBody MemberDto.MemberAddReq memberAddReq) {
         MemberDto.ChannelMemberResponse response = channelService.addMembers(channelId, memberAddReq);
         return ResponseEntity.accepted().body(response);
+    }
+
+    @GetMapping("/channels/{channelId}")
+    @Operation(summary = "채널 상세 조회", description = "특정 채널의 상세 정보를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "채널 상세 조회 성공")
+    public ResponseEntity<ChannelResponse> getChannel(@PathVariable Long channelId) {
+        Channel channel = channelService.getChannelById(channelId);
+        ChannelResponse response = new ChannelResponse(channel.getId(), channel.getName());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ktb10/munggaebe/channel/service/ChannelService.java
+++ b/src/main/java/com/ktb10/munggaebe/channel/service/ChannelService.java
@@ -108,4 +108,10 @@ public class ChannelService {
         return new MemberDto.ChannelMemberResponse(canPost, channelId, addedMembers);
     }
 
+    @Transactional(readOnly = true)
+    public Channel getChannelById(Long channelId) {
+        return channelRepository.findById(channelId)
+                .orElseThrow(() -> new RuntimeException("Channel not found with id: " + channelId));
+    }
+
 }


### PR DESCRIPTION
## 📝작업 내용
- `GET /api/v1/channels/{channelId}`: 특정 채널 상세 조회, 해당 채널 아이디(id)와 이름(name) 반환합니다.

### Channel API 추가
![8B0FB37B-4AB2-4711-87B5-CD6CF66D7CB1_4_5005_c](https://github.com/user-attachments/assets/60f63f81-236d-4775-ba7d-4e42c82291a6)



